### PR TITLE
fix: add missing module field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "typings": "./src/index.d.ts",
   "main": "./src/index.cjs",
+  "module": "./src/index.mjs",
   "exports": {
     "import": "./src/index.mjs",
     "require": "./src/index.cjs"


### PR DESCRIPTION
Unfortunately Webpack (at least Webpack 4 which is in CRA and others) does not recognize the conditional exports format yet.

For some reason this is breaking our elements build, but anyhow it should be fine to have `module` as a fallback.